### PR TITLE
Configure basePath for GitHub Pages deployment

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  basePath: process.env.NODE_ENV === "production" ? "/pomodoro-timer" : "",
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
Adds basePath configuration in next.config.ts to handle absolute paths correctly when deployed to GitHub Pages.

**Why:**
- Local dev: absolute paths resolve to http://localhost:3000/
- GitHub Pages: absolute paths resolve to https://oliseonwu.github.io/
- Without basePath, assets like '/sounds/ding.mp3' would incorrectly try to load from root instead of project subdirectory

**Fix:**
basePath: '/pomodoro-timer' ensures assets load from: https://oliseonwu.github.io/pomodoro-timer/sounds/ding.mp3 not https://oliseonwu.github.io/sounds/ding.mp3 (THROWS ERROR)